### PR TITLE
Refactor main entry point

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - '8443:8443'
     volumes:
       - 'wordpress_data:/bitnami/wordpress'
+      # linking phel-lang from local to vendor
+      - '../../phel-lang/phel-lang:/bitnami/phel-lang'
       # plugin mount cannot be inside named volume mount at least initially
       # https://github.com/moby/moby/issues/26051#issuecomment-125618978 (?)
       # workaround by symlinking plugin into plugins dir in post-init script

--- a/docker-post-init-scripts/2_composer_install.sh
+++ b/docker-post-init-scripts/2_composer_install.sh
@@ -1,2 +1,9 @@
-cd /bitnami/wordpress/wp-content/plugins/phel-wp-plugin
+cd /bitnami/wordpress/wp-content/plugins/phel-wp-plugin || exit
 composer install --no-cache
+
+# if "local phel-lang" is not empty
+if [ -d "/bitnami/phel-lang" ] && [ "$(ls -A /bitnami/phel-lang 2>/dev/null)" ]; then
+  # override vendor phel-lang with symlink pointing to "local phel-lang"
+  rm -rf /bitnami/wordpress/wp-content/plugins/phel-wp-plugin/vendor/phel-lang/phel-lang
+  ln -s /bitnami/phel-lang /bitnami/wordpress/wp-content/plugins/phel-wp-plugin/vendor/phel-lang/phel-lang
+fi

--- a/phel-config.php
+++ b/phel-config.php
@@ -1,9 +1,16 @@
 <?php
-$projectRootDir = __DIR__ . '/';
+
+use Phel\Config\PhelConfig;
 
 ini_set('xdebug.max_stack_frames', 300);
 ini_set('xdebug.max_nesting_level', 300);
 
-return (new \Phel\Config\PhelConfig())
-    ->setErrorLogFile($projectRootDir . 'error.log')
-    ->setSrcDirs(['src']);
+return (new PhelConfig())
+    ->setSrcDirs(['src'])
+    ->setTestDirs(['tests'])
+    ->setVendorDir('vendor')
+    ->setErrorLogFile('data/error.log')
+    ->setIgnoreWhenBuilding(['src/local.phel'])
+    ->setNoCacheWhenBuilding([])
+    ->setKeepGeneratedTempFiles(false)
+    ->setFormatDirs(['src', 'tests']);

--- a/src/main.phel
+++ b/src/main.phel
@@ -4,14 +4,14 @@
 (def posts (php/get_posts
             (to-php-array {"post_type" "post"
                            "numberposts" 2})))
+(defn current-user-name []
+  (-> (php/wp_get_current_user)
+      (php/-> user_login)))
 
 (defn phel-widget-content []
   (println "Hello, World!")
   (println "Your WordPress account name is: ")
-
-  (-> (php/wp_get_current_user)
-      (php/-> user_login)
-      println)
+  (println (current-user-name))
 
   (println (html [:div
                   [:h2 "All Posts"]


### PR DESCRIPTION
## Goal

Enable overriding `phel-lang` code locally from vendor linked to the `phel-wp-plugin` on runtime.
This is very helpful to experiment and visualise how changes on phel-lang side would affect/help the wp-plugin project.